### PR TITLE
Fix deps detection with trailing comma in fragments array

### DIFF
--- a/src/helpers/get-queries.ts
+++ b/src/helpers/get-queries.ts
@@ -14,7 +14,9 @@ export function* getQueries(code: string): Generator<Query> {
   for (const match of code.matchAll(QUERY_PATTERN)) {
     const source = match.groups!.source!;
     const name = match.groups!.name!;
-    const frags = match.groups?.frags?.split(",").map((frag) => frag.trim());
+    const frags = match.groups?.frags?.split(",")
+      .map((frag) => frag.trim())
+      .filter((frag) => frag.length > 0); // a empty fragment will be detected if there's a trailing comma, filtering it out
 
     yield {
       index: [match.index, match.index + match[0].length],


### PR DESCRIPTION
If the `fragments` array has a trailing comma, the dependencies detection will add a empty `""` dep which will in turn cause an error later during the process.  This PR fixes this problem by filtering out empty strings from the `frags` array.

To test this, try building a project that has a call like this:

```js
const testMutation = graphql(
  `mutation test() {}`, 
  [
    fragment,
  ]
)
```

And you'll get this error:
```
[vite] (client) Pre-transform error: Fragment  not found
```